### PR TITLE
fixed link to the NOAA-ORR-ERD organization

### DIFF
--- a/GithubGuidanceforDepartmentofCommerce.md
+++ b/GithubGuidanceforDepartmentofCommerce.md
@@ -67,7 +67,7 @@ mkruger@doc.gov.
 
 [USPTO](www.github.com/uspto)
 
-[NOAAORRERD](www.github.com/NOAAORRERD)
+[NOAAORRERD](www.github.com/NOAA-ORR-ERD)
 
 [NMML](www.github.com/NMML)
 


### PR DESCRIPTION
I noticed that you have linked to the gitHub organization we've set up for the NOAA Office of Response and Restoration Emergecny response division, but the link was wrong -- I've corrected it (it is NOAA-ORR-ERD, not NOAAORRERD)
